### PR TITLE
Add User-Agent header and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,14 @@ remote_read:
 The Prometheus Connector will use the default credentials provider implemented in the AWS SDK for Go instead of allowing users 
 to provide the credentials through command-line flags. This prevents sensitive data from being easily scraped.
 
+## User-Agent Header
+
+The Prometheus Connector uses the following `User-Agent` header for all requests:
+
+```
+User-Agent: Prometheus Connector/<version> aws-sdk-go/<version> (go<version>; <os>; <cpu arch>)
+```
+
 # Developer Documentation
 
 ## Building the Prometheus Connector from Source

--- a/timestream/client.go
+++ b/timestream/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+    "github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/timestreamquery"
 	"github.com/aws/aws-sdk-go/service/timestreamquery/timestreamqueryiface"
@@ -41,12 +42,18 @@ import (
 type labelOperation string
 type longMetricsOperation func(measureValueName string) (labelOperation, error)
 
+var addUserAgent = request.NamedHandler {
+    Name: "UserAgentHandler",
+    Fn: request.MakeAddToUserAgentHandler("Prometheus Connector", Version),
+}
+
 // Store the initialization function calls to allow unit tests to mock the creation of real clients.
 var initWriteClient = func(config *aws.Config) (timestreamwriteiface.TimestreamWriteAPI, error) {
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err
 	}
+    sess.Handlers.Build.PushFrontNamed(addUserAgent)
 	return timestreamwrite.New(sess), nil
 }
 var initQueryClient = func(config *aws.Config) (timestreamqueryiface.TimestreamQueryAPI, error) {
@@ -54,6 +61,7 @@ var initQueryClient = func(config *aws.Config) (timestreamqueryiface.TimestreamQ
 	if err != nil {
 		return nil, err
 	}
+    sess.Handlers.Build.PushFrontNamed(addUserAgent)
 	return timestreamquery.New(sess), nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
"Prometheus Connector," and the version of the Prometheus connector, has been added to the User-Agent header, before the current value in the User-Agent header, which is the AWS SDK and its version.

Example from logs with DEBUG log-level:

```
User-Agent: Prometheus Connector/1.1.0 aws-sdk-go/1.35.7 (go1.21.1; darwin; arm64)
```

Also, details on what the `User-Agent` header value is for the Prometheus Connector has been added to the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
