### PR TITLE
Integrating Documentation Revisions from Game Day

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -43,22 +43,24 @@ This getting started guide defines the following terms:
 
 ### Create a database and table on Amazon Timestream
 
+> **NOTE:** Replace the <*region*> value with the deployment region.
+
 1. Create a database called `prometheusDatabase` by running the following command in a command-line interface:
 
    ```shell
-   aws timestream-write create-database --database-name prometheusDatabase
+   aws timestream-write create-database --database-name prometheusDatabase --region <region>
    ```
 
 2. Create a table called `prometheusMetricsTable` within `prometheusDatabase` with the following command:
 
    ```shell
-   aws timestream-write create-table --database-name prometheusDatabase --table-name prometheusMetricsTable
+   aws timestream-write create-table --database-name prometheusDatabase --table-name prometheusMetricsTable --region <region>
    ```
 
 3. Run the following `describe-table` command to ensure that the database and table creation succeeded:
 
    ```shell
-   aws timestream-write describe-table --database-name prometheusDatabase --table-name prometheusMetricsTable
+   aws timestream-write describe-table --database-name prometheusDatabase --table-name prometheusMetricsTable --region <region>
    ```
 
 ## Configure Prometheus Connector
@@ -174,6 +176,8 @@ It is recommended to enable TLS encryption between Prometheus and the Prometheus
 
 4. Add the following configuration to the end of `prometheus.yml`:
 
+> **NOTE:** All configuration options are *case-sensitive*, and *session_token* authentication parameter is not supported for MFA authenticated AWS users.
+
    ```
    remote_write:
      - url: "http://localhost:9201/write"
@@ -216,6 +220,8 @@ It is recommended to enable TLS encryption between Prometheus and the Prometheus
 It is recommended to secure the Prometheus requests with TLS encryption. This can be achieved by specifying the certificate authority file the `tls_config` section for Prometheus' remote read and remote write configuration. To generate self-signed certificates during development see the [Creating Self-signed TLS Certificates](#creating-self-signed-tls-certificates) section.
 
 Here is an example of `remote_write` and `remote_read` configuration with TLS, where `RootCA.pem` is within the same directory as the Prometheus configuration file:
+
+> **NOTE:** All configuration options are *case-sensitive*, and *session_token* authentication parameter is not supported for MFA authenticated AWS users.
 
 ```yaml
 remote_write:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To configure Prometheus to read and write to remote storage, configure the `remo
 
 2. Configure the basic authentication header for Prometheus read and write requests with valid IAM credentials.
 
+> **NOTE:** All configuration options are *case-sensitive*, and *session_token* authentication parameter is not supported for MFA authenticated AWS users.
+
     ```yaml
     basic_auth:
       username: accessKey
@@ -72,14 +74,18 @@ To configure Prometheus to read and write to remote storage, configure the `remo
     ```yaml
     basic_auth:
       username: accessKey
-      password_file: credentials/secretAccessKey.txt
+      password_file: /Users/user/Desktop/credentials/secretAccessKey.txt
     ```
 
-    >  **NOTE**: As a security best practice, it is recommended to regularly [rotate IAM user access keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey).
+The *password_file* path must be the absolute path for the file, and the password file must contain only the value for the *aws_secret_access_key*.
+
+>  **NOTE**: As a security best practice, it is recommended to regularly [rotate IAM user access keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey).
 
 3. It is recommended to secure the Prometheus requests with TLS encryption. This can be achieved by specifying the certificate authority file in the `tls_config` section for Prometheus' remote read and remote write configuration. To generate self-signed certificates during development see the [Creating Self-signed TLS Certificates](#creating-self-signed-tls-certificates) section.
 
     Here is an example of `remote_write` and `remote_read` configuration with TLS, where `RootCA.pem` is within the same directory as the Prometheus configuration file:
+
+> **NOTE:** All configuration options are *case-sensitive*, and *session_token* authentication parameter is not supported for MFA authenticated AWS users.
 
     ```yaml
     remote_write:

--- a/serverless/DEVELOPER_README.md
+++ b/serverless/DEVELOPER_README.md
@@ -145,8 +145,6 @@ To view the full set of `sam deploy` options see the [sam deploy documentation](
 
 ## Configuration
 
-> **NOTE:** All configuration options are *case-sensitive*.
-
 ### Configure Prometheus
 
 To let the Lambda function know which database/table destination is for a Prometheus time series,
@@ -155,11 +153,9 @@ two additional labels need to be added in every Prometheus time series through [
 
 2. Replace the `InvokeWriteURL` and `InvokeReadURL` with the API Gateway URLs from deployment, and provide the appropriate IAM credentials in `basic_auth` before adding the following sections to the configuration file:
 
-```yaml
-global:
-  scrape_interval:    60s
-  evaluation_interval: 60s
+> **NOTE:** All configuration options are *case-sensitive*, and *session_token* authentication parameter is not supported for MFA authenticated AWS users.
 
+```yaml
 scrape_configs:
   - job_name: 'prometheus'
     scrape_interval:    15s
@@ -186,6 +182,13 @@ remote_read:
   basic_auth:
       username: accessKey
       password_file: passwordFile
+```
+
+The *password_file* path must be the absolute path for the file, and the password file must contain only the value for the *aws_secret_access_key*.
+
+The *url* values for *remote_read* and *remote_write* will be outputs from the cloudformation deployment. See the following exmaple for a remote write url:
+```
+url: "https://foo9l30.execute-api.us-east-1.amazonaws.com/dev/write"
 ```
 
 ### Start Prometheus
@@ -235,6 +238,8 @@ The user **deploying** this project **must** have the following permissions list
 [sns](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsns.html#amazonsns-actions-as-permissions)
 [iam](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html#awsidentityandaccessmanagementiam-actions-as-permissions)
 
+
+> **NOTE** - This policy is too long to be added inline during user creation, and must be created as a policy and attached to the user instead.
 
 ```json
 {


### PR DESCRIPTION
### Summary

Integrate all changes noted in the feedback from game day.

### Description
Add the following changes into the documentation for the Prometheus Connector:
- Note lack of support for the `session_token` field for MFA authenticated AWS users
- Note the format for the contents of the password file used for authenticating the AWS user in the Prometheus configuration
- Note the requirement for needing the absolute path of the password file in the Prometheus configuration
- Note that the deployment user policy is too long to be set inline during user creation
- Remove global section in the example for the Prometheus configuration file
- Add region portion to the CLI commands that create the timestream database and tables

Resolved Issues:
- N/A