### PR TITLE
Update one-click deployment links and IAM policy with public S3 buckets

### DIFF
--- a/serverless/DEVELOPER_README.md
+++ b/serverless/DEVELOPER_README.md
@@ -483,7 +483,7 @@ The `TimestreamLambdaRole` is the role used by the template in order to permit A
 
 ## Conclusion
 
-Following the above steps you should be able to monitor your Timestream database using Prometheus. Ensure all items in the following list can be verified to ensure the guide has been completed correctly:
+Following the above steps you should be able to ingest and query your Prometheus data in Timestream. Ensure all items in the following list can be verified to confirm the guide has been completed correctly:
 - The `PrometheusMetricsTable` table in the `PrometheusDatabase` database is empty.
 - AWS CLI is configured with the correct region wishing to deploy connector to.
 - User access key id is set.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Update all links for one-click deployment with the appropriate regions and buckets supported for Timestream. The IAM deployment policy has been updated with the new S3 buckets for successful deployment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
