### PR TITLE
Update template Go version & connector version

### DIFF
--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -78,11 +78,11 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Role: !GetAtt "IAMLambdaRole.Arn"
-      CodeUri: ./timestream-prometheus-connector-linux-amd64-1.1.0.zip
+      CodeUri: ./timestream-prometheus-connector-linux-amd64-1.0.0.zip
       Description: "Prometheus remote storage connector for Amazon Timestream"
-      Handler: "timestream-prometheus-connector-linux-amd64-1.1.0"
+      Handler: "timestream-prometheus-connector-linux-amd64-1.0.0"
       MemorySize: !Ref "MemorySize"
-      Runtime: "go1.x"
+      Runtime: "provided.al2023"
       Environment:
         Variables:
           default_database: !Ref "DefaultDatabase"


### PR DESCRIPTION
- `go1.x` runtime is no longer supported for Lambda functions, causing deployments to fail, this has been updated to `provided.al2023`.
- The connector version in `template.yml` has been changed from `1.1.0` to `1.0.0`.
