### PR TITLE
Update template.yml and package.py for platform.al2023 runtime

### DIFF
--- a/package.py
+++ b/package.py
@@ -42,7 +42,7 @@ def create_directory(dir_name):
     copy_tree("documentation", dir_name + "/documentation")
 
 
-def run_build(target_bin, connector_version):
+def run_build(target_bin):
     """
     Compiles a binary for the target OS.
 
@@ -58,7 +58,8 @@ def run_build(target_bin, connector_version):
         logging.error("Environment variables GOOS or GOARCH are not set.")
         return None
 
-    file_name = "timestream-prometheus-connector-{}-{}-{}".format(target_bin, arch, connector_version)
+    # Required for Lambda runtime platform.al2023
+    file_name = "bootstrap"
 
     build_command = "go build -o {}/{}".format(target_bin, file_name)
     if target_bin == "windows":
@@ -159,14 +160,16 @@ def create_tarball(target_folder, version):
     :return: The name of the precompiled binary.
     """
     create_directory(target_folder)
-    bin_name = run_build(target_folder, version)
+    bin_name = run_build(target_folder)
     if bin_name is None:
         logging.error("Cannot create binary for packaging.")
         return
 
     check_binary(target_folder, bin_name)
-    tar_dir(bin_name, target_folder)
-    return bin_name
+    arch = "amd64"
+    archive_name = "timestream-prometheus-connector-{}-{}-{}".format(target_folder, arch, version)
+    tar_dir(archive_name, target_folder)
+    return archive_name
 
 
 if __name__ == "__main__":

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -9,7 +9,7 @@ Metadata:
     LicenseUrl: "LICENSE"
     ReadmeUrl: "DEVELOPER_README.md"
     HomePageUrl: "https://aws.amazon.com/timestream/"
-    SemanticVersion: "1.1.0"
+    SemanticVersion: "1.0.0"
 
 Parameters:
   APIGatewayStageName:
@@ -78,11 +78,13 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Role: !GetAtt "IAMLambdaRole.Arn"
-      CodeUri: ./timestream-prometheus-connector-linux-amd64-1.1.0.zip
+      CodeUri: 
+          Bucket: !Sub 'timestreamassets-${AWS::Region}'
+          Key: "timestream-prometheus-connector-linux-amd64-1.0.0.zip"
       Description: "Prometheus remote storage connector for Amazon Timestream"
-      Handler: "timestream-prometheus-connector-linux-amd64-1.1.0"
+      Handler: "bootstrap"
       MemorySize: !Ref "MemorySize"
-      Runtime: "go1.x"
+      Runtime: "provided.al2023"
       Environment:
         Variables:
           default_database: !Ref "DefaultDatabase"

--- a/timestream/version.go
+++ b/timestream/version.go
@@ -19,6 +19,6 @@ import (
 
 // Application build information.
 var (
-	Version   = "1.1.0"
+	Version   = "1.0.0"
 	GoVersion = runtime.Version()
 )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- `go1.x` runtime is no longer supported for Lambda functions, causing deployments to fail, this has been updated to `provided.al2023`.
- The connector version in `template.yml` has been changed from `1.1.0` to `1.0.0`.
- Handler has been changed to `bootstrap` to match the instructions to migrate from `go1.x` to `provided.al2023`.
- The template will get the Lambda function code from the public bucket matching `AWS::Region`.
- `package.py` now names the binary `bootstrap`, but still packages the binary and documentation in an archive named `timestream-prometheus-connect-<os>-<arch>-<version>`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
