### PR TITLE
Fix Flakey Linter Action

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -23,7 +23,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1

--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -35,7 +35,7 @@ jobs:
           GO111MODULE: on
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: go build -v .
@@ -47,7 +47,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: 'stable'
@@ -56,7 +56,7 @@ jobs:
           GO111MODULE: on
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.54
-          args: --exclude ".Log(.*)|format.Set|level.Set"
+          args: --exclude ".Log(.*)|format.Set|level.Set" --timeout=2m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           GO111MODULE: on
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set env
         run: |
           echo "VERSION=$(echo ${GITHUB_REF#refs/*/} | cut -c 2-)" >> $GITHUB_ENV


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fix golangci-lint action that usually fails on first execution.  Linter action has timeout errors so I increased the timeout to 2 mins which has fixed the problem. I also upgraded the other action versions to avoid the node deprecation warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
