### PR TITLE
Changing Logging of Records and Errors to Debug Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,12 @@ Configure the Prometheus Connector to retry up to 10 times upon recoverable erro
 | `log.level` | `log_level` |  Sets the output level for logs. | No | `info` | `info`, `warn`, `debug`, `error` |
 | `log.format` | `log_format` |  Sets the output format for the logs. The output for logs always goes to stderr, unless the logging has been disabled. | No | `logfmt` | `logfmt`, `json` |
 
+Setting log levels:
+- SAM CLI - `sam deploy --parameter-overrides "LogLevel=Debug"`
+- One-click deployment - Update the `log_level` environment variable when configuring the deployment parameters
+  - With an already deployed Lambda you can edit the environment variable `log_level` in the Lambda configuration
+- Local execution - `./bootstrap --default-database=PrometheusDatabase  --default-table=PrometheusMetricsTable --log.level=info`
+
 >**NOTE**: The logging level is ***by default*** set to `info`. Set `log.level` to `debug` to view any Samples ignored due to long metric name or non-finite values.
 
 `fail-on-long-label` &mdash; Prometheus recommends using meaningful and detailed metrics names, which may result in metric names exceeding the maximum length (256 bytes) supported by Amazon Timestream.
@@ -862,6 +868,8 @@ openssl x509 -req -sha256 -days 365 -in serverCertificateSigningRequest.csr -out
 
 # Troubleshooting
 ## Prometheus Connector Specific Errors
+
+> **Note**: Errors and records are only logged with debug mode. With the default log level of `info`, only the high level errors are logged. See [Logger Configuration Options](#logger-configuration-options) for how to adjust the logging level.
 
 All connector-specific errors can be found in [`errors/errors.go`](./errors/errors.go).
 

--- a/timestream/utils.go
+++ b/timestream/utils.go
@@ -21,7 +21,8 @@ import (
 
 // LogError logs the provided error with the given message.
 func LogError(logger log.Logger, msg string, err error, keyvals ...interface{}) {
-	level.Error(logger).Log(append([]interface{}{"message", msg, "error", err}, keyvals...)...)
+	level.Error(logger).Log(append([]interface{}{"message", msg}, keyvals...)...)
+	level.Debug(logger).Log(err)
 }
 
 // LogDebug logs at DEBUG level with the given message and any additional key-value pairs.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:

Changed the functionality of error logging so that only the high level error is displayed with default logging levels set. Clients must enable debug logging to log specific error messages and records.

Changes Integrated:
- [x] - Tested deploying connector with SAM CLI
- [x] - Tested error logging to ensure records and errors are only logged in debug mode
- [x] - Validated IT tests pass
- [x] - Validated UT tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
