### PR TITLE
Add Documentation for Generating Keys and Certificates for TLS Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/.DS_Store
+*.tar.gz
+*.zip
+integration/tls/cert
+resources

--- a/integration/tls/README.md
+++ b/integration/tls/README.md
@@ -3,13 +3,53 @@
 ## Prerequisites
 Prior to running the tests in tls_test.go, ensure the following:
 1. Updated the basic_auth section within [prometheus.yml](./config/prometheus.yml).
-2. Download or build the Prometheus Connector Docker image and store it in a new directory named `resources` in the repository root.
+2. Complete the [Creating Self-signed TLS Certificates](#creating-self-signed-tls-certificates) if this has not been previously done and store the `RootCA.pem`, `ServerCertificate.crt`, `ServerPrivateKey.key`, and `InvalidPrivateKey.key` files in the `integration/tls/cert` folder.
+3. Download the [latest release artifact](https://github.com/awslabs/amazon-timestream-connector-prometheus/releases/latest) or build the Prometheus Connector Docker image and store it in a new directory named `resources` in the repository root.
 
 ## How to build and save the docker image
 1. Execute the following command to build the docker image:
 `docker buildx build . -t timestream-prometheus-connector-docker`
 2. Execute the following command to save the docker image as a compressed file and update the `version` appropriately:
 `docker save timestream-prometheus-connector-docker | gzip > timestream-prometheus-connector-docker-image-<version>.tar.gz`
+
+## Creating Self-signed TLS Certificates
+
+The following steps generate self-signed TLS certificates using OpenSSL.
+
+> **NOTE**: Self-signed certificates **should not** be used during production, they should only be used during development.
+
+### Creating the Certificate Authority files
+
+Use the following command to generate a private key and the root certificate file for the certificate authority.
+
+```shell
+openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout RootCA.key -out RootCA.pem -subj "/C=US/ST=Washington/L=Seattle/O=Amazon Web Services/CN=host.docker.internal"
+```
+
+### Creating the Server Key
+
+Use the following command to generate a server private key and a certificate signing request:
+
+```shell
+openssl req -days 365 -nodes -newkey rsa:2048 -keyout ServerPrivateKey.key -out ServerCertificateSigningRequest.csr -subj "/C=US/ST=Washington/L=Seattle/O=Amazon Web Services/CN=host.docker.internal"
+```
+
+### Creating the Server Certificate
+
+Use the following command to generate the self-signed server certificate:
+
+```shell
+openssl x509 -req -sha256 -days 365 -in ServerCertificateSigningRequest.csr -CA RootCA.pem -CAkey RootCA.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:host.docker.internal") -out ServerCertificate.crt
+```
+> **NOTE**: The value for DNS is set to **DNS:host.docker.internal** to associate the host name to the server certificate. This is required when running the Prometheus Connector from a Docker image or from the precompiled binaries.
+
+### Creating the Invalid Private Key
+
+Use the following command to generate the invalid private key:
+
+```shell
+openssl req -x509 -nodes -new -sha256 -days 365 -newkey rsa:2048 -keyout InvalidPrivateKey.key -subj "/C=US/ST=Washington/L=Seattle/O=Invalid Organization/CN=Invalid-CN"
+```
 
 ## How to execute tests
 1. Run the following command to execute the TLS tests:

--- a/integration/tls/tls_test.go
+++ b/integration/tls/tls_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 	"timestream-prometheus-connector/integration"
+	"timestream-prometheus-connector/timestream"
 )
 
 const (
@@ -40,15 +41,17 @@ const (
 	prometheusConfigPath       = "config/prometheus.yml"
 	prometheusDockerImageName  = "prom/prometheus"
 	tlsRootCAPath              = "cert/RootCA.pem"
+	tlsCertificatePath         = "cert/ServerCertificate.crt"
+	tlsPrivateKeyPath          = "cert/ServerPrivateKey.key"
 	tlsServerCertPath          = "cert"
 	connectorDockerImageName   = "timestream-prometheus-connector-docker"
-	connectorDockerImagePath   = "../../resources/timestream-prometheus-connector-docker-image-1.0.0.tar.gz"
 	defaultDatabaseCMD         = "--default-database=tlsDB"
 	defaultTableCMD            = "--default-table=tls"
-	tlsCertificateCMD          = "--tls-certificate=/root/cert/serverCertificate.crt"
-	tlsKeyCMD                  = "--tls-key=/root/cert/serverPrivateKey.key"
-	tlsUnmatchedCertificateCMD = "--tls-certificate=/root/cert/rootCA.pem"
-	tlsInvalidKeyFileCMD       = "--tls-key=/root/cert/invalidPrivateKey.key"
+	tlsCertificateCMD          = "--tls-certificate=/root/cert/ServerCertificate.crt"
+	tlsKeyCMD                  = "--tls-key=/root/cert/ServerPrivateKey.key"
+	tlsUnmatchedCertificateCMD = "--tls-certificate=/root/cert/RootCA.pem"
+	tlsInvalidKeyFileCMD       = "--tls-key=/root/cert/InvalidPrivateKey.key"
+	tlsInvalidKeyPath          = "cert/InvalidPrivateKey.key"
 	region                     = "us-east-1"
 	database                   = "tlsDB"
 	table                      = "tls"
@@ -78,12 +81,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestHttpsSupport(t *testing.T) {
+	// Ensure required testing files exists
+	validateFileExists(t, tlsRootCAPath)
+	validateFileExists(t, tlsCertificatePath)
+	validateFileExists(t, tlsPrivateKeyPath)
+
 	dockerClient, ctx := integration.CreateDockerClient(t)
 
 	bindString := []string{fmt.Sprintf("%s:/root/cert:ro", getAbsolutionPath(t, tlsServerCertPath))}
 
 	connectorConfig := integration.ConnectorContainerConfig{
-		DockerImage:       connectorDockerImagePath,
+		DockerImage:       "../../resources/timestream-prometheus-connector-docker-image-" + timestream.Version + ".tar.gz",
 		ImageName:         connectorDockerImageName,
 		Binds:             bindString,
 		ConnectorCommands: connectorTLSCMDs,
@@ -129,12 +137,15 @@ func TestHttpsSupportWithInvalidCertificate(t *testing.T) {
 		{"test with invalid file type", connectorCMDsWithInvalidFile},
 	}
 
+	// Ensure invalid key file exists
+	validateFileExists(t, tlsInvalidKeyPath)
+
 	bindString := []string{fmt.Sprintf("%s:/root/cert:ro", getAbsolutionPath(t, tlsServerCertPath))}
 
 	dockerClient, ctx := integration.CreateDockerClient(t)
 	for _, test := range invalidTestCase {
 		connectorConfig := integration.ConnectorContainerConfig{
-			DockerImage:       connectorDockerImagePath,
+			DockerImage:       "../../resources/timestream-prometheus-connector-docker-image-" + timestream.Version + ".tar.gz",
 			ImageName:         connectorDockerImageName,
 			Binds:             bindString,
 			ConnectorCommands: test.command,
@@ -148,6 +159,12 @@ func TestHttpsSupportWithInvalidCertificate(t *testing.T) {
 	}
 
 	integration.StopContainer(t, dockerClient, ctx, containerIDs)
+}
+
+// Check wether a file exists.
+func validateFileExists(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	require.NoError(t, err)
 }
 
 // getAbsolutionPath gets the absolution path of the giving file.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:

Add documentation covering how to generate TLS keys and certificates for TLS tests. Fixed bug where invalid tests would pass without an invalid certificate in the `integration/tls/cert` directory.

Follow the steps to create certificates and keys in the TLS README.

Execute tests to ensure fix is working with the following commands in the repository root:
```
go clean -testcache
go test -v ./integration/tls
```

Changes Integrated:
- [x] - Validated tls tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.