### PR TITLE
Make deployment user permissions more specific

### DIFF
--- a/serverless/DEVELOPER_README.md
+++ b/serverless/DEVELOPER_README.md
@@ -280,7 +280,11 @@ The user **deploying** this project **must** have the following permissions list
 				"apigateway:PUT",
 				"apigateway:TagResource"
 			],
-			"Resource": "*"
+			"Resource": [
+				"arn:aws:apigateway:<region>::/apis/*",
+				"arn:aws:apigateway:<region>::/apis",
+				"arn:aws:apigateway:<region>::/tags/*"
+			]
 		},
 		{
 			"Sid": "VisualEditor1",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- The API Gateway permissions documented in `serverless/DEVELOPER_README.md` for the deployment user have been made more specific.

- [x] Tested deployment with new permissions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
